### PR TITLE
Force full Supervisor boot on outer-container restart

### DIFF
--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -22,6 +22,19 @@ echo UTC > /etc/timezone
 
 mount --make-rshared /mnt/data
 
+# Force Supervisor to treat each outer-container start as a fresh host boot.
+# `/proc/stat` is mirrored from the real host kernel here, so its `btime`
+# stays stable across outer-container restarts. Supervisor compares that host
+# btime with the persisted /mnt/data/supervisor/config.json last_boot and may
+# classify a container restart as "Detected Supervisor restart", skipping
+# Home Assistant/add-on boot.
+# https://github.com/qweritos/haos-one/issues/35
+if [ -f /mnt/data/supervisor/config.json ]; then
+  if config_json="$(jq '.last_boot = "1970-01-01T00:00:01+00:00"' /mnt/data/supervisor/config.json)"; then
+    printf '%s\n' "$config_json" > /mnt/data/supervisor/config.json
+  fi
+fi
+
 # Optionally disable NetworkManager via systemd masking.
 case "${USE_DUMMY_NETWORKMANAGER:-1}" in
   1|true|TRUE|yes|YES|on|ON)


### PR DESCRIPTION
Fixes #35

Supervisor persists `last_boot` in `/mnt/data/supervisor/config.json` and compares it with `/proc/stat` `btime` on startup. In this containerized setup, `/proc/stat` is mirrored from the host kernel, so `btime` stays stable across outer-container restarts and Supervisor can incorrectly classify a plain container restart as `Detected Supervisor restart`.

This updates the entrypoint to reset the persisted `last_boot` before systemd starts, forcing a full Supervisor boot after `docker compose stop` / `docker compose start` on the same container.

Validation:
- `sh -n rootfs/entrypoint.sh`
- fresh Compose boot with port `8123` exposed
- `docker compose stop` then `docker compose start` on the same container id
- no `Detected Supervisor restart` in `journalctl -u hassos-supervisor.service`
- `homeassistant` returned to `Up` after restart

Note: separate fresh-boot runs can still hit an unrelated `containerd` layer-lock race during image installation; this PR is only for the Supervisor restart-detection path.