### PR TITLE
Add compat container Docker socket interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ docker exec -it haos systemctl restart docker
 
 | Name | Description | Default |
 | --- | --- | --- |
-| `USE_DUMMY_NETWORKMANAGER` | Disable NetworkManager and enable `haos-one-compat` | `1` |
+| `USE_DUMMY_NETWORKMANAGER` | Disable NetworkManager and enable the dummy responder inside `haos-one-compat` | `1` |
 | `DISABLE_UDEV` | Disable in-container udev services | `1` |
 | `DEV` | Used for development purposes - mount live `haos-one-compat` code volume | `0` |
 

--- a/docs/haos-one-compat.md
+++ b/docs/haos-one-compat.md
@@ -1,0 +1,255 @@
+# `haos_one_compat`
+
+`haos_one_compat` is a small helper container started inside the HAOS guest.
+It exists to provide compatibility shims that make Home Assistant Supervisor
+behave like it is running on a normal HAOS host, without changing Supervisor
+itself.
+
+Today it has two jobs:
+
+- a D-Bus shim for NetworkManager
+- a Docker socket interceptor
+
+## Lifecycle
+
+`haos-one-compat.service` builds and runs the container early in boot.
+
+Important pieces:
+
+- host service: `/etc/systemd/system/haos-one-compat.service`
+- socket override: `/etc/systemd/system/docker.socket.d/override.conf`
+- process entrypoint: `/opt/haos-one-compat/haos_one_compat/__main__.py`
+
+The service mounts:
+
+- `/run/dbus` into the container so the dummy NetworkManager can talk on the host bus
+- `/run` into the container as `/host-run` so the Docker proxy can own the guest-facing socket
+
+The compat service must be up before Supervisor starts using Docker. The systemd unit
+waits until `/run/docker.sock` exists before continuing.
+
+## D-Bus Shim
+
+The D-Bus part emulates only the NetworkManager surface Supervisor actually uses.
+It is intentionally narrow and state-light.
+
+Code:
+
+- `/opt/haos-one-compat/haos_one_compat/dummy_nm.py`
+
+Behavior:
+
+- exports a fake `org.freedesktop.NetworkManager`
+- implements only the methods/properties Supervisor queries
+- returns stable, synthetic data instead of managing real host networking
+
+This is enabled by `USE_DUMMY_NETWORKMANAGER=1`, which is the current default.
+If disabled, the compat container still runs for Docker interception, but the dummy
+NetworkManager task is skipped.
+
+### D-Bus Validation
+
+Inside the running `haos` container:
+
+```bash
+systemctl is-active haos-one-compat.service
+journalctl -u haos-one-compat.service -n 50 --no-pager
+```
+
+Expected log line:
+
+```text
+Dummy NetworkManager service running on system bus
+```
+
+If Supervisor still reports NetworkManager issues, inspect:
+
+- `journalctl -u haos-one-compat.service`
+- `journalctl -u hassos-supervisor.service`
+
+## Docker Interceptor
+
+The Docker daemon does not listen on `/run/docker.sock` directly anymore.
+Instead:
+
+- the real dockerd socket is moved to `/run/docker-real.sock`
+- `haos_one_compat` binds `/run/docker.sock`
+- the compat proxy forwards requests to `/run/docker-real.sock`
+
+This is done by overriding `docker.socket`:
+
+```ini
+[Socket]
+ListenStream=
+ListenStream=/run/docker-real.sock
+```
+
+The proxy code is here:
+
+- `/opt/haos-one-compat/haos_one_compat/docker_proxy.py`
+- `/opt/haos-one-compat/haos_one_compat/docker_rules.py`
+
+### Why it exists
+
+Supervisor marks the system unsupported when it sees extra software outside the
+expected Home Assistant container set. In this project, the extra container is
+`haos_one_compat` itself.
+
+The relevant Supervisor logic is in `../supervisor/supervisor/resolution/evaluations/container.py`:
+
+- it lists Docker containers
+- it resolves image metadata
+- unknown images become `UnsupportedReason.SOFTWARE`
+
+Instead of patching Supervisor, the proxy filters the compat container out of the
+Docker API response Supervisor consumes.
+
+### What is intercepted
+
+The current scope is intentionally small:
+
+- `/containers/json`
+  - hides `haos_one_compat`
+- `/info`
+  - adds `Warnings: ["HAOS compat: intercepted"]`
+
+Everything else is passed through unchanged.
+
+Notably:
+
+- `/version` is not modified
+- container inspect payloads are not rewritten
+- network APIs are not rewritten
+- request bodies are not modified
+
+### Keep-alive caveat and fix
+
+The main runtime bug during development was that `curl` looked correct, but
+`docker ps` still showed `haos_one_compat`.
+
+Root cause:
+
+- the original proxy made a one-time decision per connection
+- Docker CLI sends `HEAD /_ping` first
+- then it sends `GET /containers/json` on the same keep-alive socket
+- after the first pass-through decision, the later list call was no longer rewritten
+
+The proxy now inspects each HTTP request on persistent connections and only switches
+to raw bidirectional relay for streaming or hijacked endpoints such as logs, stats,
+attach, and exec streams.
+
+## Docker Validation
+
+Inside the running `haos` container:
+
+```bash
+systemctl is-active haos-one-compat.service
+ls -l /run/docker.sock /run/docker-real.sock
+docker -H unix:///run/docker.sock ps
+docker -H unix:///run/docker-real.sock ps
+docker -H unix:///run/docker.sock info
+```
+
+Expected:
+
+- `/run/docker.sock` exists and is owned by the proxy
+- `/run/docker-real.sock` exists and is owned by dockerd
+- `docker -H unix:///run/docker.sock ps` does not show `haos_one_compat`
+- `docker -H unix:///run/docker-real.sock ps` does show `haos_one_compat`
+- `docker -H unix:///run/docker.sock info` shows warning `HAOS compat: intercepted`
+
+Raw API checks:
+
+```bash
+curl --unix-socket /run/docker.sock -s http://localhost/containers/json?all=1 | jq .
+curl --unix-socket /run/docker-real.sock -s http://localhost/containers/json?all=1 | jq .
+curl --unix-socket /run/docker.sock -s http://localhost/info | jq .
+```
+
+Expected:
+
+- proxied `/containers/json` omits `/haos_one_compat`
+- real `/containers/json` includes `/haos_one_compat`
+- proxied `/info` contains `Warnings` entry `HAOS compat: intercepted`
+
+## Debugging
+
+### Service state
+
+```bash
+systemctl status haos-one-compat.service --no-pager
+systemctl status docker.socket docker.service --no-pager
+systemctl status hassos-supervisor.service --no-pager
+```
+
+### Logs
+
+```bash
+journalctl -u haos-one-compat.service -n 100 --no-pager
+journalctl -u hassos-supervisor.service -n 100 --no-pager
+```
+
+Useful things to look for:
+
+- `Docker socket proxy listening on /host-run/docker.sock -> /host-run/docker-real.sock`
+- `Dummy NetworkManager service running on system bus`
+- Docker daemon connection errors from Supervisor
+- `start-limit-hit` on `hassos-supervisor.service` after a temporary socket outage
+
+If Supervisor hit start limits after a failed boot sequence:
+
+```bash
+systemctl reset-failed hassos-supervisor.service
+systemctl start hassos-supervisor.service
+```
+
+### Socket sanity
+
+```bash
+ss -xlpn | grep docker
+```
+
+Expected:
+
+- dockerd listens on `/run/docker-real.sock`
+- the compat proxy owns `/run/docker.sock`
+
+### Common failure modes
+
+`docker ps` still shows `haos_one_compat`
+
+- verify you are using `/run/docker.sock`, not `/run/docker-real.sock`
+- verify `haos-one-compat.service` restarted after code changes
+- compare raw API output from both sockets
+- if `curl` is correct but Docker CLI is wrong, suspect keep-alive handling again
+
+Supervisor cannot connect to Docker
+
+- ensure `haos-one-compat.service` is active
+- ensure `/run/docker.sock` exists
+- ensure `docker.socket` override still points dockerd to `/run/docker-real.sock`
+- reset Supervisor start limits if needed
+
+Unsupported software warning still appears
+
+- confirm proxied `/containers/json` does not contain `/haos_one_compat`
+- inspect Supervisor logs after restart
+- if needed, inspect `../supervisor/supervisor/resolution/evaluations/container.py`
+
+## Tests
+
+Local tests for the compat container are here:
+
+- `/opt/haos-one-compat/tests/test_docker_rules.py`
+- `/opt/haos-one-compat/tests/test_docker_proxy.py`
+
+Useful commands:
+
+```bash
+python3 -m unittest discover -s /opt/haos-one-compat/tests -p 'test_*.py'
+python3 -m py_compile /opt/haos-one-compat/haos_one_compat/docker_proxy.py \
+  /opt/haos-one-compat/haos_one_compat/docker_rules.py
+```
+
+For runtime validation, prefer a real `haos-one` container over synthetic local-only
+checks, because the socket ordering and systemd behavior matter here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
 # haos-one Docs
 
-**🚧 Under Construction**
-
-Check back soon.
+- [haos_one_compat container](./haos-one-compat.md)

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -35,20 +35,28 @@ if [ -f /mnt/data/supervisor/config.json ]; then
   fi
 fi
 
-# Optionally disable NetworkManager via systemd masking.
+use_dummy_networkmanager=0
 case "${USE_DUMMY_NETWORKMANAGER:-1}" in
   1|true|TRUE|yes|YES|on|ON)
+    use_dummy_networkmanager=1
     ln -sf /dev/null /etc/systemd/system/NetworkManager.service
-    mkdir -p /etc/systemd/system/multi-user.target.wants
-    ln -sf /etc/systemd/system/haos-one-compat.service /etc/systemd/system/multi-user.target.wants/haos-one-compat.service
-    mkdir -p /etc/systemd/system/hassos-supervisor.service.d
-    cat > /etc/systemd/system/hassos-supervisor.service.d/override.conf <<'EOF'
+    ;;
+esac
+
+mkdir -p /etc/systemd/system/multi-user.target.wants
+ln -sf /etc/systemd/system/haos-one-compat.service /etc/systemd/system/multi-user.target.wants/haos-one-compat.service
+mkdir -p /etc/systemd/system/hassos-supervisor.service.d
+cat > /etc/systemd/system/hassos-supervisor.service.d/override.conf <<'EOF'
 [Unit]
 After=haos-one-compat.service
 Requires=haos-one-compat.service
 EOF
-    ;;
-esac
+mkdir -p /etc/systemd/system/haos-one-compat.service.d
+cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -v /run/dbus:/run/dbus -v /run:/host-run haos_one_compat
+EOF
 
 # Optionally disable udev via systemd masking.
 case "${DISABLE_UDEV:-1}" in
@@ -79,11 +87,10 @@ fi
 
 case "${DEV:-0}" in
   1|true|TRUE|yes|YES|on|ON)
-    mkdir -p /etc/systemd/system/haos-one-compat.service.d
-    cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<'EOF'
+    cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<EOF
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker run --name haos_one_compat -v /run/dbus:/run/dbus -v /opt/haos-one-compat:/opt/haos-one-compat haos_one_compat
+ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -v /run/dbus:/run/dbus -v /run:/host-run -v /opt/haos-one-compat:/opt/haos-one-compat haos_one_compat
 EOF
     ;;
 esac

--- a/rootfs/etc/systemd/system/docker.socket.d/override.conf
+++ b/rootfs/etc/systemd/system/docker.socket.d/override.conf
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=
+ListenStream=/run/docker-real.sock

--- a/rootfs/etc/systemd/system/haos-one-compat.service
+++ b/rootfs/etc/systemd/system/haos-one-compat.service
@@ -5,9 +5,11 @@ Wants=docker.service
 
 [Service]
 Type=simple
+Environment=DOCKER_HOST=unix:///run/docker-real.sock
 ExecStartPre=-/usr/bin/docker rm -f haos_one_compat
 ExecStartPre=/usr/bin/docker build -t haos_one_compat /opt/haos-one-compat
-ExecStart=/usr/bin/docker run --name haos_one_compat -v /run/dbus:/run/dbus haos_one_compat
+ExecStart=/usr/bin/docker run --name haos_one_compat -v /run/dbus:/run/dbus -v /run:/host-run haos_one_compat
+ExecStartPost=/bin/sh -ec 'i=0; while [ "$i" -lt 100 ]; do [ -S /run/docker.sock ] && exit 0; i=$((i + 1)); sleep 0.1; done; echo "haos_one_compat docker proxy socket not ready" >&2; exit 1'
 ExecStop=/usr/bin/docker stop haos_one_compat
 Restart=always
 RestartSec=2s

--- a/rootfs/etc/systemd/system/hassio-supervisor-patcher.service
+++ b/rootfs/etc/systemd/system/hassio-supervisor-patcher.service
@@ -2,6 +2,8 @@
 Description=Patch hassio_supervisor container after start
 After=docker.service
 Wants=docker.service
+After=haos-one-compat.service
+Requires=haos-one-compat.service
 
 [Service]
 Type=simple

--- a/rootfs/opt/haos-one-compat/README.md
+++ b/rootfs/opt/haos-one-compat/README.md
@@ -1,7 +1,11 @@
-# Dummy NetworkManager D-Bus Service
+# haos_one_compat
 
-This is a tiny, fake NetworkManager D-Bus responder. 
-It implements only the NetworkManager methods/properties that
+This container runs two compatibility shims:
+
+- a tiny fake NetworkManager D-Bus responder
+- a Docker UNIX-socket proxy that filters `/containers/json` and lightly tags `/info`
+
+The dummy NetworkManager service implements only the methods and properties that
 Supervisor uses, with static data and minimal state updates.
 
 Run on the session bus (default):

--- a/rootfs/opt/haos-one-compat/haos_one_compat/__main__.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/__main__.py
@@ -1,6 +1,89 @@
-"""Module entrypoint for dummy NetworkManager service."""
+"""Module entrypoint for compat services."""
 
-from .dummy_nm import main
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+
+from .docker_proxy import DockerSocketProxy
+from .dummy_nm import build_arg_parser as build_dummy_nm_arg_parser
+from .dummy_nm import run_service as run_dummy_nm_service
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _env_enabled(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def build_arg_parser():
+    parser = build_dummy_nm_arg_parser()
+    parser.description = "haos_one_compat services"
+    parser.add_argument(
+        "--frontend-socket",
+        default="/host-run/docker.sock",
+        help="Frontend Docker API UNIX socket path",
+    )
+    parser.add_argument(
+        "--upstream-socket",
+        default="/host-run/docker-real.sock",
+        help="Upstream Docker API UNIX socket path",
+    )
+    return parser
+
+
+async def run_services(args) -> None:
+    proxy = DockerSocketProxy(
+        frontend_path=args.frontend_socket,
+        upstream_path=args.upstream_socket,
+    )
+    tasks = {
+        asyncio.create_task(proxy.serve_forever(), name="docker-proxy"),
+    }
+
+    if _env_enabled("USE_DUMMY_NETWORKMANAGER", True):
+        tasks.add(asyncio.create_task(run_dummy_nm_service(args), name="dummy-nm"))
+    else:
+        _LOGGER.info("Dummy NetworkManager disabled")
+
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+    first_error: BaseException | None = None
+    for task in done:
+        try:
+            task.result()
+        except Exception as exc:  # pragma: no cover - exercised by integration behavior
+            first_error = exc
+            break
+        first_error = RuntimeError(f"{task.get_name()} exited unexpectedly")
+        break
+
+    for task in pending:
+        task.cancel()
+    for task in pending:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    await proxy.close()
+
+    if first_error is not None:
+        raise first_error
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    asyncio.run(run_services(args))
 
 
 if __name__ == "__main__":

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
@@ -1,0 +1,347 @@
+"""UNIX socket proxy for Docker API interception."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import stat
+from dataclasses import dataclass
+from email.parser import Parser
+from typing import Iterable
+
+from .docker_rules import is_rewrite_target, rewrite_json_payload
+
+_LOGGER = logging.getLogger(__name__)
+_HTTP_HEADER_LIMIT = 1024 * 1024
+_READ_CHUNK_SIZE = 64 * 1024
+
+
+@dataclass(slots=True)
+class HTTPRequestHead:
+    method: str
+    path: str
+    version: str
+    headers: list[tuple[str, str]]
+    raw: bytes
+
+    def header(self, name: str) -> str | None:
+        target = name.lower()
+        for key, value in self.headers:
+            if key.lower() == target:
+                return value
+        return None
+
+
+@dataclass(slots=True)
+class HTTPResponse:
+    version: str
+    status_code: int
+    reason: str
+    headers: list[tuple[str, str]]
+    body: bytes
+    raw: bytes
+
+    def header(self, name: str) -> str | None:
+        target = name.lower()
+        for key, value in self.headers:
+            if key.lower() == target:
+                return value
+        return None
+
+
+async def _read_header_block(reader: asyncio.StreamReader) -> bytes:
+    header = bytearray()
+    while b"\r\n\r\n" not in header:
+        chunk = await reader.readuntil(b"\r\n")
+        header.extend(chunk)
+        if len(header) > _HTTP_HEADER_LIMIT:
+            raise ValueError("HTTP header too large")
+    return bytes(header)
+
+
+def _parse_headers(header_bytes: bytes) -> list[tuple[str, str]]:
+    text = header_bytes.decode("iso-8859-1")
+    parsed = Parser().parsestr(text)
+    return list(parsed.items())
+
+
+async def _read_request_head(reader: asyncio.StreamReader) -> HTTPRequestHead:
+    raw = await _read_header_block(reader)
+    start_line, header_blob = raw.split(b"\r\n", 1)
+    method, path, version = start_line.decode("iso-8859-1").split(" ", 2)
+    return HTTPRequestHead(
+        method=method,
+        path=path,
+        version=version,
+        headers=_parse_headers(header_blob),
+        raw=raw,
+    )
+
+
+async def _read_chunked_body(
+    reader: asyncio.StreamReader,
+) -> tuple[bytes, bytes]:
+    decoded = bytearray()
+    raw = bytearray()
+
+    while True:
+        size_line = await reader.readuntil(b"\r\n")
+        raw.extend(size_line)
+        size = int(size_line.split(b";", 1)[0].strip(), 16)
+        if size == 0:
+            while True:
+                trailer = await reader.readuntil(b"\r\n")
+                raw.extend(trailer)
+                if trailer == b"\r\n":
+                    return bytes(decoded), bytes(raw)
+        chunk = await reader.readexactly(size)
+        decoded.extend(chunk)
+        raw.extend(chunk)
+        ending = await reader.readexactly(2)
+        raw.extend(ending)
+
+
+async def _forward_request_body(
+    request: HTTPRequestHead,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    content_length = request.header("Content-Length")
+    transfer_encoding = request.header("Transfer-Encoding")
+
+    if content_length:
+        remaining = int(content_length)
+        while remaining > 0:
+            chunk = await reader.read(min(_READ_CHUNK_SIZE, remaining))
+            if not chunk:
+                raise ConnectionError("client closed while sending request body")
+            remaining -= len(chunk)
+            writer.write(chunk)
+            await writer.drain()
+        return
+
+    if transfer_encoding and "chunked" in transfer_encoding.lower():
+        _, raw = await _read_chunked_body(reader)
+        writer.write(raw)
+        await writer.drain()
+
+
+async def _read_response(
+    reader: asyncio.StreamReader,
+    request_method: str,
+) -> HTTPResponse:
+    raw_header = await _read_header_block(reader)
+    start_line, header_blob = raw_header.split(b"\r\n", 1)
+    version, status_code, reason = start_line.decode("iso-8859-1").split(" ", 2)
+    headers = _parse_headers(header_blob)
+    response = HTTPResponse(
+        version=version,
+        status_code=int(status_code),
+        reason=reason,
+        headers=headers,
+        body=b"",
+        raw=raw_header,
+    )
+
+    if request_method == "HEAD" or response.status_code in (204, 304):
+        return response
+
+    transfer_encoding = response.header("Transfer-Encoding")
+    content_length = response.header("Content-Length")
+
+    if transfer_encoding and "chunked" in transfer_encoding.lower():
+        body, raw_body = await _read_chunked_body(reader)
+        response.body = body
+        response.raw += raw_body
+        return response
+
+    if content_length:
+        body = await reader.readexactly(int(content_length))
+        response.body = body
+        response.raw += body
+        return response
+
+    body = await reader.read()
+    response.body = body
+    response.raw += body
+    return response
+
+
+def _serialize_headers(headers: Iterable[tuple[str, str]]) -> bytes:
+    lines = [f"{key}: {value}".encode("iso-8859-1") for key, value in headers]
+    return b"\r\n".join(lines)
+
+
+def rewrite_http_response(path: str, response: HTTPResponse) -> bytes:
+    """Return either the original raw response or a rewritten JSON response."""
+    content_type = response.header("Content-Type") or ""
+    content_encoding = response.header("Content-Encoding") or ""
+
+    if response.status_code < 200 or response.status_code >= 300:
+        return response.raw
+    if "json" not in content_type.lower():
+        return response.raw
+    if content_encoding and content_encoding.lower() != "identity":
+        return response.raw
+
+    rewritten_body = rewrite_json_payload(path, response.body)
+    if rewritten_body == response.body:
+        return response.raw
+
+    headers = [
+        (key, value)
+        for key, value in response.headers
+        if key.lower() not in {"content-length", "transfer-encoding"}
+    ]
+    headers.append(("Content-Length", str(len(rewritten_body))))
+    status_line = (
+        f"{response.version} {response.status_code} {response.reason}".encode("iso-8859-1")
+    )
+    header_blob = _serialize_headers(headers)
+    parts = [status_line, b"\r\n"]
+    if header_blob:
+        parts.extend((header_blob, b"\r\n"))
+    parts.extend((b"\r\n", rewritten_body))
+    return b"".join(parts)
+
+
+async def _pipe(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    while True:
+        chunk = await reader.read(_READ_CHUNK_SIZE)
+        if not chunk:
+            break
+        writer.write(chunk)
+        await writer.drain()
+
+
+async def _bidirectional_relay(
+    client_reader: asyncio.StreamReader,
+    client_writer: asyncio.StreamWriter,
+    upstream_reader: asyncio.StreamReader,
+    upstream_writer: asyncio.StreamWriter,
+) -> None:
+    tasks = {
+        asyncio.create_task(_pipe(client_reader, upstream_writer)),
+        asyncio.create_task(_pipe(upstream_reader, client_writer)),
+    }
+    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    for task in pending:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    for task in done:
+        with contextlib.suppress(ConnectionError, BrokenPipeError):
+            task.result()
+
+
+class DockerSocketProxy:
+    """Expose the intercepted Docker API on a frontend UNIX socket."""
+
+    def __init__(self, frontend_path: str, upstream_path: str) -> None:
+        self.frontend_path = frontend_path
+        self.upstream_path = upstream_path
+        self._server: asyncio.AbstractServer | None = None
+
+    async def _wait_for_upstream(self, timeout: float = 30.0) -> None:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while True:
+            try:
+                if stat.S_ISSOCK(os.stat(self.upstream_path).st_mode):
+                    reader, writer = await asyncio.open_unix_connection(self.upstream_path)
+                    writer.close()
+                    await writer.wait_closed()
+                    return
+            except (FileNotFoundError, ConnectionError, OSError):
+                pass
+
+            if asyncio.get_running_loop().time() >= deadline:
+                raise RuntimeError(f"upstream Docker socket not ready: {self.upstream_path}")
+            await asyncio.sleep(0.1)
+
+    def _remove_stale_frontend(self) -> None:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(self.frontend_path)
+
+    def _mirror_frontend_permissions(self) -> None:
+        upstream_stat = os.stat(self.upstream_path)
+        os.chown(self.frontend_path, upstream_stat.st_uid, upstream_stat.st_gid)
+        os.chmod(self.frontend_path, stat.S_IMODE(upstream_stat.st_mode))
+
+    async def start(self) -> None:
+        await self._wait_for_upstream()
+        self._remove_stale_frontend()
+        self._server = await asyncio.start_unix_server(
+            self._handle_client,
+            path=self.frontend_path,
+            start_serving=False,
+        )
+        self._mirror_frontend_permissions()
+        await self._server.start_serving()
+        _LOGGER.info(
+            "Docker socket proxy listening on %s -> %s",
+            self.frontend_path,
+            self.upstream_path,
+        )
+
+    async def close(self) -> None:
+        if self._server is None:
+            return
+        self._server.close()
+        await self._server.wait_closed()
+        self._server = None
+        self._remove_stale_frontend()
+
+    async def serve_forever(self) -> None:
+        await self.start()
+        if self._server is None:
+            raise RuntimeError("proxy server failed to start")
+        async with self._server:
+            await self._server.serve_forever()
+
+    async def _handle_client(
+        self,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+    ) -> None:
+        upstream_reader: asyncio.StreamReader | None = None
+        upstream_writer: asyncio.StreamWriter | None = None
+
+        try:
+            request = await _read_request_head(client_reader)
+            upstream_reader, upstream_writer = await asyncio.open_unix_connection(
+                self.upstream_path
+            )
+            upstream_writer.write(request.raw)
+            await upstream_writer.drain()
+
+            if is_rewrite_target(request.path):
+                await _forward_request_body(request, client_reader, upstream_writer)
+                response = await _read_response(upstream_reader, request.method)
+                client_writer.write(rewrite_http_response(request.path, response))
+                await client_writer.drain()
+                return
+
+            await _bidirectional_relay(
+                client_reader,
+                client_writer,
+                upstream_reader,
+                upstream_writer,
+            )
+        except asyncio.IncompleteReadError:
+            _LOGGER.debug("connection closed while reading Docker API stream")
+        except Exception:
+            _LOGGER.exception("Docker proxy request failed")
+        finally:
+            if upstream_writer is not None:
+                upstream_writer.close()
+                with contextlib.suppress(Exception):
+                    await upstream_writer.wait_closed()
+            client_writer.close()
+            with contextlib.suppress(Exception):
+                await client_writer.wait_closed()

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
@@ -16,6 +16,13 @@ from .docker_rules import is_rewrite_target, rewrite_json_payload
 _LOGGER = logging.getLogger(__name__)
 _HTTP_HEADER_LIMIT = 1024 * 1024
 _READ_CHUNK_SIZE = 64 * 1024
+_TUNNEL_PATH_MARKERS = (
+    "/attach",
+    "/events",
+    "/exec/",
+    "/logs",
+    "/stats",
+)
 
 
 @dataclass(slots=True)
@@ -207,6 +214,32 @@ def rewrite_http_response(path: str, response: HTTPResponse) -> bytes:
     return b"".join(parts)
 
 
+def _header_contains(headers: list[tuple[str, str]], name: str, token: str) -> bool:
+    target = name.lower()
+    expected = token.lower()
+    for key, value in headers:
+        if key.lower() != target:
+            continue
+        if expected in value.lower():
+            return True
+    return False
+
+
+def _request_wants_tunnel(request: HTTPRequestHead) -> bool:
+    if _header_contains(request.headers, "Connection", "upgrade"):
+        return True
+    path = request.path.lower()
+    return any(marker in path for marker in _TUNNEL_PATH_MARKERS)
+
+
+def _uses_keep_alive(version: str, headers: list[tuple[str, str]]) -> bool:
+    connection_close = _header_contains(headers, "Connection", "close")
+    connection_keepalive = _header_contains(headers, "Connection", "keep-alive")
+    if version == "HTTP/1.0":
+        return connection_keepalive
+    return not connection_close
+
+
 async def _pipe(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
@@ -313,26 +346,36 @@ class DockerSocketProxy:
         upstream_writer: asyncio.StreamWriter | None = None
 
         try:
-            request = await _read_request_head(client_reader)
             upstream_reader, upstream_writer = await asyncio.open_unix_connection(
                 self.upstream_path
             )
-            upstream_writer.write(request.raw)
-            await upstream_writer.drain()
-
-            if is_rewrite_target(request.path):
+            while True:
+                request = await _read_request_head(client_reader)
+                upstream_writer.write(request.raw)
+                await upstream_writer.drain()
                 await _forward_request_body(request, client_reader, upstream_writer)
-                response = await _read_response(upstream_reader, request.method)
-                client_writer.write(rewrite_http_response(request.path, response))
-                await client_writer.drain()
-                return
 
-            await _bidirectional_relay(
-                client_reader,
-                client_writer,
-                upstream_reader,
-                upstream_writer,
-            )
+                if _request_wants_tunnel(request):
+                    await _bidirectional_relay(
+                        client_reader,
+                        client_writer,
+                        upstream_reader,
+                        upstream_writer,
+                    )
+                    return
+
+                response = await _read_response(upstream_reader, request.method)
+                if is_rewrite_target(request.path):
+                    client_writer.write(rewrite_http_response(request.path, response))
+                else:
+                    client_writer.write(response.raw)
+                await client_writer.drain()
+
+                if not (
+                    _uses_keep_alive(request.version, request.headers)
+                    and _uses_keep_alive(response.version, response.headers)
+                ):
+                    return
         except asyncio.IncompleteReadError:
             _LOGGER.debug("connection closed while reading Docker API stream")
         except Exception:

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
@@ -1,0 +1,66 @@
+"""Docker API rewrite rules for the compat proxy."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+_TARGET_RE = re.compile(r"^/(?:v[^/]+/)?(info|containers/json)$")
+_HIDDEN_CONTAINER_NAMES = {"/haos_one_compat", "haos_one_compat"}
+
+
+def normalize_target_path(path: str) -> str | None:
+    """Normalize Docker API target paths across versioned and raw endpoints."""
+    match = _TARGET_RE.match(urlsplit(path).path)
+    if match is None:
+        return None
+    return f"/{match.group(1)}"
+
+
+def is_rewrite_target(path: str) -> bool:
+    """Return True when the request path should be rewritten."""
+    return normalize_target_path(path) is not None
+
+
+def rewrite_json_payload(path: str, payload: bytes) -> bytes:
+    """Rewrite the JSON body for supported Docker API endpoints."""
+    target = normalize_target_path(path)
+    if target is None:
+        return payload
+
+    try:
+        data = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return payload
+
+    if target == "/info":
+        if not isinstance(data, dict):
+            return payload
+        data["HAOSCompat"] = "intercepted"
+    elif target == "/containers/json":
+        if not isinstance(data, list):
+            return payload
+        data = [
+            container
+            for container in data
+            if not _should_hide_container(container)
+        ]
+
+    return json.dumps(data, separators=(",", ":")).encode("utf-8")
+
+
+def _should_hide_container(container: Any) -> bool:
+    """Return True when a container should be hidden from the Docker API."""
+    if not isinstance(container, dict):
+        return False
+
+    names = container.get("Names")
+    if isinstance(names, list) and any(name in _HIDDEN_CONTAINER_NAMES for name in names):
+        return True
+
+    if container.get("Image") == "haos_one_compat":
+        return True
+
+    return False

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 
 _TARGET_RE = re.compile(r"^/(?:v[^/]+/)?(info|containers/json)$")
 _HIDDEN_CONTAINER_NAMES = {"/haos_one_compat", "haos_one_compat"}
+_INFO_WARNING = "HAOS compat: intercepted"
 
 
 def normalize_target_path(path: str) -> str | None:
@@ -38,7 +39,12 @@ def rewrite_json_payload(path: str, payload: bytes) -> bytes:
     if target == "/info":
         if not isinstance(data, dict):
             return payload
-        data["HAOSCompat"] = "intercepted"
+        warnings = data.get("Warnings")
+        if isinstance(warnings, list):
+            if _INFO_WARNING not in warnings:
+                warnings.append(_INFO_WARNING)
+        else:
+            data["Warnings"] = [_INFO_WARNING]
     elif target == "/containers/json":
         if not isinstance(data, list):
             return payload

--- a/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
@@ -44,49 +44,47 @@ class DockerProxyTests(unittest.IsolatedAsyncioTestCase):
         writer: asyncio.StreamWriter,
     ) -> None:
         try:
-            header = await reader.readuntil(b"\r\n\r\n")
-        except asyncio.IncompleteReadError:
+            while True:
+                try:
+                    header = await reader.readuntil(b"\r\n\r\n")
+                except asyncio.IncompleteReadError:
+                    return
+
+                request_line = header.split(b"\r\n", 1)[0].decode("ascii")
+                _, path, _ = request_line.split(" ", 2)
+                self.requests.append(path)
+
+                if path == "/containers/json?all=1":
+                    payload = json.dumps(
+                        [
+                            {"Id": "1", "Names": ["/haos_one_compat"], "Image": "haos_one_compat"},
+                            {"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"},
+                        ]
+                    ).encode("utf-8")
+                elif path == "/info":
+                    payload = b'{"unchanged":true}'
+                    writer.write(
+                        b"HTTP/1.1 200 OK\r\n"
+                        b"Content-Type: application/json\r\n"
+                        b"Transfer-Encoding: chunked\r\n\r\n"
+                    )
+                    writer.write(f"{len(payload):X}\r\n".encode("ascii"))
+                    writer.write(payload + b"\r\n0\r\n\r\n")
+                    await writer.drain()
+                    continue
+                else:
+                    payload = b'{"unchanged":true}'
+
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
+                    + payload
+                )
+                await writer.drain()
+        finally:
             writer.close()
             await writer.wait_closed()
-            return
-
-        request_line = header.split(b"\r\n", 1)[0].decode("ascii")
-        _, path, _ = request_line.split(" ", 2)
-        self.requests.append(path)
-
-        if path == "/containers/json?all=1":
-            payload = json.dumps(
-                [
-                    {"Id": "1", "Names": ["/haos_one_compat"], "Image": "haos_one_compat"},
-                    {"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"},
-                ]
-            ).encode("utf-8")
-        elif path == "/info":
-            payload = b'{"unchanged":true}'
-            writer.write(
-                b"HTTP/1.1 200 OK\r\n"
-                b"Content-Type: application/json\r\n"
-                b"Transfer-Encoding: chunked\r\n\r\n"
-            )
-            writer.write(f"{len(payload):X}\r\n".encode("ascii"))
-            writer.write(payload + b"\r\n0\r\n\r\n")
-            await writer.drain()
-            writer.close()
-            await writer.wait_closed()
-            return
-        else:
-            payload = b'{"unchanged":true}'
-
-        writer.write(
-            b"HTTP/1.1 200 OK\r\n"
-            b"Content-Type: application/json\r\n"
-            + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
-            + payload
-        )
-
-        await writer.drain()
-        writer.close()
-        await writer.wait_closed()
 
     async def _request(self, path: str) -> tuple[str, bytes]:
         reader, writer = await asyncio.open_unix_connection(str(self.frontend_path))
@@ -100,12 +98,15 @@ class DockerProxyTests(unittest.IsolatedAsyncioTestCase):
         header, body = raw.split(b"\r\n\r\n", 1)
         return header.decode("iso-8859-1"), body
 
-    async def test_info_response_has_compat_marker(self) -> None:
+    async def test_info_response_has_compat_warning(self) -> None:
         header, body = await self._request("/info")
 
         self.assertIn("Content-Length", header)
         self.assertNotIn("Transfer-Encoding", header)
-        self.assertEqual(json.loads(body), {"unchanged": True, "HAOSCompat": "intercepted"})
+        self.assertEqual(
+            json.loads(body),
+            {"unchanged": True, "Warnings": ["HAOS compat: intercepted"]},
+        )
 
     async def test_passthrough_for_non_target_endpoint(self) -> None:
         header, body = await self._request("/containers/json")
@@ -118,6 +119,28 @@ class DockerProxyTests(unittest.IsolatedAsyncioTestCase):
         header, body = await self._request("/containers/json?all=1")
 
         self.assertIn("Content-Length", header)
+        self.assertEqual(
+            json.loads(body),
+            [{"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"}],
+        )
+
+    async def test_keep_alive_ping_then_container_list_still_rewrites(self) -> None:
+        reader, writer = await asyncio.open_unix_connection(str(self.frontend_path))
+        writer.write(
+            b"HEAD /_ping HTTP/1.1\r\nHost: localhost\r\n"
+            b"Connection: keep-alive\r\n\r\n"
+            b"GET /containers/json?all=1 HTTP/1.1\r\nHost: localhost\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        await writer.drain()
+        raw = await reader.read()
+        writer.close()
+        await writer.wait_closed()
+
+        responses = raw.split(b"HTTP/1.1 ")[1:]
+        self.assertEqual(len(responses), 2)
+        self.assertIn(b"200 OK\r\n", responses[0])
+        body = responses[1].split(b"\r\n\r\n", 1)[1]
         self.assertEqual(
             json.loads(body),
             [{"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"}],

--- a/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from haos_one_compat.docker_proxy import DockerSocketProxy
+
+
+class DockerProxyTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.upstream_path = self.root / "docker-real.sock"
+        self.frontend_path = self.root / "docker.sock"
+        self.requests: list[str] = []
+        self.upstream_server = await asyncio.start_unix_server(
+            self._handle_upstream,
+            path=str(self.upstream_path),
+        )
+        self.proxy = DockerSocketProxy(
+            frontend_path=str(self.frontend_path),
+            upstream_path=str(self.upstream_path),
+        )
+        await self.proxy.start()
+
+    async def asyncTearDown(self) -> None:
+        await self.proxy.close()
+        self.upstream_server.close()
+        await self.upstream_server.wait_closed()
+        self.tempdir.cleanup()
+
+    async def _handle_upstream(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            header = await reader.readuntil(b"\r\n\r\n")
+        except asyncio.IncompleteReadError:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        request_line = header.split(b"\r\n", 1)[0].decode("ascii")
+        _, path, _ = request_line.split(" ", 2)
+        self.requests.append(path)
+
+        if path == "/containers/json?all=1":
+            payload = json.dumps(
+                [
+                    {"Id": "1", "Names": ["/haos_one_compat"], "Image": "haos_one_compat"},
+                    {"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"},
+                ]
+            ).encode("utf-8")
+        elif path == "/info":
+            payload = b'{"unchanged":true}'
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Transfer-Encoding: chunked\r\n\r\n"
+            )
+            writer.write(f"{len(payload):X}\r\n".encode("ascii"))
+            writer.write(payload + b"\r\n0\r\n\r\n")
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+            return
+        else:
+            payload = b'{"unchanged":true}'
+
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
+            + payload
+        )
+
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    async def _request(self, path: str) -> tuple[str, bytes]:
+        reader, writer = await asyncio.open_unix_connection(str(self.frontend_path))
+        writer.write(
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n".encode("ascii")
+        )
+        await writer.drain()
+        raw = await reader.read()
+        writer.close()
+        await writer.wait_closed()
+        header, body = raw.split(b"\r\n\r\n", 1)
+        return header.decode("iso-8859-1"), body
+
+    async def test_info_response_has_compat_marker(self) -> None:
+        header, body = await self._request("/info")
+
+        self.assertIn("Content-Length", header)
+        self.assertNotIn("Transfer-Encoding", header)
+        self.assertEqual(json.loads(body), {"unchanged": True, "HAOSCompat": "intercepted"})
+
+    async def test_passthrough_for_non_target_endpoint(self) -> None:
+        header, body = await self._request("/containers/json")
+
+        self.assertIn("Content-Length", header)
+        self.assertEqual(json.loads(body), {"unchanged": True})
+        self.assertEqual(self.requests[-1], "/containers/json")
+
+    async def test_filters_compat_from_container_list(self) -> None:
+        header, body = await self._request("/containers/json?all=1")
+
+        self.assertIn("Content-Length", header)
+        self.assertEqual(
+            json.loads(body),
+            [{"Id": "2", "Names": ["/kept"], "Image": "busybox:latest"}],
+        )
+
+    async def test_replaces_stale_frontend_socket_path(self) -> None:
+        await self.proxy.close()
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(self.frontend_path)
+        self.frontend_path.write_text("stale")
+
+        self.proxy = DockerSocketProxy(
+            frontend_path=str(self.frontend_path),
+            upstream_path=str(self.upstream_path),
+        )
+        await self.proxy.start()
+
+        mode = os.stat(self.frontend_path).st_mode
+        self.assertTrue(stat.S_ISSOCK(mode))
+        upstream_gid = os.stat(self.upstream_path).st_gid
+        self.assertEqual(os.stat(self.frontend_path).st_gid, upstream_gid)

--- a/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
@@ -22,18 +22,22 @@ class DockerRulesTests(unittest.TestCase):
         self.assertIsNone(normalize_target_path("/version"))
         self.assertIsNone(normalize_target_path("/containers/abc/json"))
 
-    def test_rewrite_info_adds_compat_marker_only(self) -> None:
+    def test_rewrite_info_adds_compat_warning_only(self) -> None:
         payload = json.dumps(
             {
                 "OperatingSystem": "Home Assistant OS 17.1",
                 "Architecture": "x86_64",
                 "Driver": "overlay2",
+                "Warnings": ["existing warning"],
             }
         ).encode("utf-8")
 
         rewritten = json.loads(rewrite_json_payload("/info", payload))
 
-        self.assertEqual(rewritten["HAOSCompat"], "intercepted")
+        self.assertEqual(
+            rewritten["Warnings"],
+            ["existing warning", "HAOS compat: intercepted"],
+        )
         self.assertEqual(rewritten["OperatingSystem"], "Home Assistant OS 17.1")
         self.assertEqual(rewritten["Architecture"], "x86_64")
         self.assertEqual(rewritten["Driver"], "overlay2")

--- a/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from haos_one_compat.docker_rules import normalize_target_path, rewrite_json_payload
+
+
+class DockerRulesTests(unittest.TestCase):
+    def test_normalize_target_path_handles_versioned_and_plain_endpoints(self) -> None:
+        self.assertEqual(normalize_target_path("/info"), "/info")
+        self.assertEqual(normalize_target_path("/v1.47/info"), "/info")
+        self.assertEqual(normalize_target_path("/containers/json"), "/containers/json")
+        self.assertEqual(
+            normalize_target_path("/v1.47/containers/json?all=1"),
+            "/containers/json",
+        )
+        self.assertIsNone(normalize_target_path("/version"))
+        self.assertIsNone(normalize_target_path("/containers/abc/json"))
+
+    def test_rewrite_info_adds_compat_marker_only(self) -> None:
+        payload = json.dumps(
+            {
+                "OperatingSystem": "Home Assistant OS 17.1",
+                "Architecture": "x86_64",
+                "Driver": "overlay2",
+            }
+        ).encode("utf-8")
+
+        rewritten = json.loads(rewrite_json_payload("/info", payload))
+
+        self.assertEqual(rewritten["HAOSCompat"], "intercepted")
+        self.assertEqual(rewritten["OperatingSystem"], "Home Assistant OS 17.1")
+        self.assertEqual(rewritten["Architecture"], "x86_64")
+        self.assertEqual(rewritten["Driver"], "overlay2")
+
+    def test_rewrite_containers_hides_compat_container(self) -> None:
+        payload = json.dumps(
+            [
+                {"Id": "1", "Names": ["/haos_one_compat"], "Image": "haos_one_compat"},
+                {"Id": "2", "Names": ["/hassio_supervisor"], "Image": "ghcr.io/home-assistant/amd64-hassio-supervisor:latest"},
+            ]
+        ).encode("utf-8")
+
+        rewritten = json.loads(rewrite_json_payload("/v1.48/containers/json?all=1", payload))
+
+        self.assertEqual(rewritten, [{"Id": "2", "Names": ["/hassio_supervisor"], "Image": "ghcr.io/home-assistant/amd64-hassio-supervisor:latest"}])
+
+    def test_non_target_payload_is_unchanged(self) -> None:
+        payload = b'{"Version":"29.1.3","Os":"linux","Arch":"amd64"}'
+        self.assertEqual(rewrite_json_payload("/version", payload), payload)


### PR DESCRIPTION
This brings the `haos_one_compat` runtime support into `master`.

Included here:
- start `haos_one_compat` before Supervisor
- move the real Docker socket to `/run/docker-real.sock`
- expose `/run/docker.sock` through the compat proxy
- hide `haos_one_compat` from `/containers/json` so Supervisor does not flag unsupported software
- add a small compat marker to `docker info`
- keep the compat docs in `docs/haos-one-compat.md`

Validation:
- `python3 -m unittest discover -s rootfs/opt/haos-one-compat/tests -p "test_*.py"`
- `sh -n rootfs/entrypoint.sh`