### PR TITLE
Publish moving HAOS major version tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,6 +46,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve major version tag
+        id: major-version-tag
+        shell: bash
+        run: |
+          major_tag=""
+          if [[ "${HAOS_VERSION}" =~ ^([0-9]+)\. ]]; then
+            major_tag="${BASH_REMATCH[1]}"
+          fi
+          echo "tag=${major_tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -56,7 +66,9 @@ jobs:
           tags: |
             type=raw,value=${{ env.TAG_BASE }}-amd64
             type=raw,value=${{ env.HAOS_VERSION }}-amd64,enable=${{ env.HAOS_VERSION != '' }}
+            type=raw,value=${{ steps.major-version-tag.outputs.tag }}-amd64,enable=${{ steps.major-version-tag.outputs.tag != '' }}
             type=raw,value=${{ github.ref_name }}-${{ env.HAOS_VERSION }}-amd64,enable=${{ env.HAOS_VERSION != '' && github.ref_name != 'master' }}
+            type=raw,value=${{ github.ref_name }}-${{ steps.major-version-tag.outputs.tag }}-amd64,enable=${{ steps.major-version-tag.outputs.tag != '' && github.ref_name != 'master' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -94,6 +106,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve major version tag
+        id: major-version-tag
+        shell: bash
+        run: |
+          major_tag=""
+          if [[ "${HAOS_VERSION}" =~ ^([0-9]+)\. ]]; then
+            major_tag="${BASH_REMATCH[1]}"
+          fi
+          echo "tag=${major_tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -104,7 +126,9 @@ jobs:
           tags: |
             type=raw,value=${{ env.TAG_BASE }}-arm64
             type=raw,value=${{ env.HAOS_VERSION }}-arm64,enable=${{ env.HAOS_VERSION != '' }}
+            type=raw,value=${{ steps.major-version-tag.outputs.tag }}-arm64,enable=${{ steps.major-version-tag.outputs.tag != '' }}
             type=raw,value=${{ github.ref_name }}-${{ env.HAOS_VERSION }}-arm64,enable=${{ env.HAOS_VERSION != '' && github.ref_name != 'master' }}
+            type=raw,value=${{ github.ref_name }}-${{ steps.major-version-tag.outputs.tag }}-arm64,enable=${{ steps.major-version-tag.outputs.tag != '' && github.ref_name != 'master' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -147,6 +171,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch manifests
+        shell: bash
         run: |
           docker buildx imagetools create -t "${IMAGE_NAME}:${TAG_BASE}" \
             "${IMAGE_NAME}:${TAG_BASE}-amd64" \
@@ -168,6 +193,26 @@ jobs:
               docker buildx imagetools create -t "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${HAOS_VERSION}" \
                 "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${HAOS_VERSION}-amd64" \
                 "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${HAOS_VERSION}-arm64"
+            fi
+            major_tag=""
+            if [[ "${HAOS_VERSION}" =~ ^([0-9]+)\. ]]; then
+              major_tag="${BASH_REMATCH[1]}"
+            fi
+            if [ -n "${major_tag}" ]; then
+              docker buildx imagetools create -t "${IMAGE_NAME}:${major_tag}" \
+                "${IMAGE_NAME}:${major_tag}-amd64" \
+                "${IMAGE_NAME}:${major_tag}-arm64"
+              docker buildx imagetools create -t "${DOCKERHUB_IMAGE}:${major_tag}" \
+                "${DOCKERHUB_IMAGE}:${major_tag}-amd64" \
+                "${DOCKERHUB_IMAGE}:${major_tag}-arm64"
+              if [ "${GITHUB_REF_NAME}" != "master" ]; then
+                docker buildx imagetools create -t "${IMAGE_NAME}:${GITHUB_REF_NAME}-${major_tag}" \
+                  "${IMAGE_NAME}:${GITHUB_REF_NAME}-${major_tag}-amd64" \
+                  "${IMAGE_NAME}:${GITHUB_REF_NAME}-${major_tag}-arm64"
+                docker buildx imagetools create -t "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${major_tag}" \
+                  "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${major_tag}-amd64" \
+                  "${DOCKERHUB_IMAGE}:${GITHUB_REF_NAME}-${major_tag}-arm64"
+              fi
             fi
           fi
 


### PR DESCRIPTION
Builds for HAOS releases currently publish exact tags such as 18.0 only. Add moving major version tags so each 18.x build also updates tag 18 across per-arch and multi-arch images.