### PR TITLE
Fix HAOS v18 startup dependencies

### DIFF
--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -45,12 +45,6 @@ esac
 
 mkdir -p /etc/systemd/system/multi-user.target.wants
 ln -sf /etc/systemd/system/haos-one-compat.service /etc/systemd/system/multi-user.target.wants/haos-one-compat.service
-mkdir -p /etc/systemd/system/hassos-supervisor.service.d
-cat > /etc/systemd/system/hassos-supervisor.service.d/override.conf <<'EOF'
-[Unit]
-After=haos-one-compat.service
-Requires=haos-one-compat.service
-EOF
 mkdir -p /etc/systemd/system/haos-one-compat.service.d
 cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<EOF
 [Service]

--- a/rootfs/etc/systemd/system/docker.service.d/haos.conf
+++ b/rootfs/etc/systemd/system/docker.service.d/haos.conf
@@ -1,0 +1,8 @@
+[Unit]
+RequiresMountsFor=/etc/docker
+
+[Service]
+EnvironmentFile=/run/dockerd.env
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock $DOCKERD_FLAGS
+OOMScoreAdjust=-400

--- a/rootfs/etc/systemd/system/haos-one-compat.service
+++ b/rootfs/etc/systemd/system/haos-one-compat.service
@@ -9,7 +9,7 @@ Environment=DOCKER_HOST=unix:///run/docker-real.sock
 ExecStartPre=-/usr/bin/docker rm -f haos_one_compat
 ExecStartPre=/usr/bin/docker build -t haos_one_compat /opt/haos-one-compat
 ExecStart=/usr/bin/docker run --name haos_one_compat -v /run/dbus:/run/dbus -v /run:/host-run haos_one_compat
-ExecStartPost=/bin/sh -ec 'i=0; while [ "$i" -lt 100 ]; do [ -S /run/docker.sock ] && exit 0; i=$((i + 1)); sleep 0.1; done; echo "haos_one_compat docker proxy socket not ready" >&2; exit 1'
+ExecStartPost=/bin/sh -ec 'i=0; while [ "$i" -lt 600 ]; do [ -S /run/docker.sock ] && exit 0; i=$((i + 1)); sleep 0.1; done; echo "haos_one_compat docker proxy socket not ready" >&2; exit 1'
 ExecStop=/usr/bin/docker stop haos_one_compat
 Restart=always
 RestartSec=2s

--- a/rootfs/etc/systemd/system/haos-supervisor.service.d/override.conf
+++ b/rootfs/etc/systemd/system/haos-supervisor.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=haos-one-compat.service
+Requires=haos-one-compat.service

--- a/rootfs/etc/systemd/system/hassos-supervisor.service.d/override.conf
+++ b/rootfs/etc/systemd/system/hassos-supervisor.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=haos-one-compat.service
+Requires=haos-one-compat.service


### PR DESCRIPTION
HAOS 18 keeps Docker tied to masked mount units, so Docker never starts and the compat proxy/Supervisor stay down. This shadows the Docker drop-in to avoid the masked /mnt/data dependency, stores supervisor ordering as static drop-ins, and gives the compat proxy more time to publish its socket.