### PR TITLE
Make pod DNS policy configurable

### DIFF
--- a/charts/haos-one/Chart.yaml
+++ b/charts/haos-one/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: haos-one
 description: Run Home Assistant OS in a single container on Kubernetes.
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: "0.0.1"
 home: https://github.com/qweritos/haos-one
 sources:

--- a/charts/haos-one/README.md
+++ b/charts/haos-one/README.md
@@ -19,6 +19,7 @@ helm install haos-one oci://registry.andrey.wtf/charts/haos-one
 | `nameOverride` | Override chart name | empty |
 | `fullnameOverride` | Override release name | empty |
 | `hostNetwork` | Enable host networking | `false` |
+| `dnsPolicy` | Pod DNS policy | `Default` |
 | `useDummyNetworkManager` | Enable dummy NetworkManager inside the container | `true` |
 | `disableUdev` | Mask udev units via systemd in entrypoint | `true` |
 | `service.enabled` | Create a Service | `true` |

--- a/charts/haos-one/templates/statefulset.yaml
+++ b/charts/haos-one/templates/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       {{- end }}
     spec:
       hostNetwork: {{ .Values.hostNetwork }}
-      dnsPolicy: {{ ternary "ClusterFirstWithHostNet" "ClusterFirst" .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
       containers:
         - name: haos-one
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/haos-one/values.schema.json
+++ b/charts/haos-one/values.schema.json
@@ -47,6 +47,12 @@
       "description": "Enable host networking for the pod.",
       "default": false
     },
+    "dnsPolicy": {
+      "type": "string",
+      "enum": ["ClusterFirstWithHostNet", "ClusterFirst", "Default"],
+      "description": "Pod DNS policy.",
+      "default": "Default"
+    },
     "useDummyNetworkManager": {
       "type": "boolean",
       "description": "Enable dummy NetworkManager inside the container.",
@@ -313,6 +319,7 @@
     "nameOverride",
     "fullnameOverride",
     "hostNetwork",
+    "dnsPolicy",
     "useDummyNetworkManager",
     "disableUdev",
     "useHostDevSerial",

--- a/charts/haos-one/values.yaml
+++ b/charts/haos-one/values.yaml
@@ -9,6 +9,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 hostNetwork: false
+dnsPolicy: Default
 useDummyNetworkManager: true
 disableUdev: true
 useHostDevSerial: true


### PR DESCRIPTION
## What changed

- add a configurable `dnsPolicy` chart value with schema validation
- use the configured policy in the StatefulSet
- document the new value
- bump the chart version to `0.0.12`

## Why

The chart previously derived DNS policy only from `hostNetwork`, which prevented deployments from selecting Kubernetes' `Default` policy or another supported policy explicitly.

## Impact

The default DNS policy is now `Default`. Deployments that need cluster DNS or host-network-aware cluster DNS can set `dnsPolicy` to `ClusterFirst` or `ClusterFirstWithHostNet`.

## Validation

- `helm lint charts/haos-one`
- rendered the chart with default values and confirmed `dnsPolicy: Default`
- rendered with `hostNetwork=true,dnsPolicy=ClusterFirstWithHostNet` and confirmed the override